### PR TITLE
chore: rename plugin to zalivator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
-# zalivator
+# Zalivator
+
+Figma plugin **Zalivator**.
+
+## Development
+
+```sh
+npm run dev
+```
+
+## Build
+
+```sh
+npm run build
+```
+
+## Publishing
+
+Ensure the package name in `package.json` and the `id` in `manifest.json` are both set to `zalivator` before publishing to Figma Community.

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Zalivator",
-  "id": "hello-world-plugin",
+  "id": "zalivator",
   "api": "1.0.0",
   "main": "dist/code.js",
   "editorType": ["figma"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "hello-world-plugin",
+  "name": "zalivator",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "hello-world-plugin",
+      "name": "zalivator",
       "version": "1.0.0",
       "devDependencies": {
         "@figma/plugin-typings": "^1.107.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "hello-world-plugin",
+  "name": "zalivator",
   "version": "1.0.0",
   "private": true,
   "type": "module",


### PR DESCRIPTION
## Summary
- rename project to `zalivator`
- align manifest ID with package name
- document new name and publish steps

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689e5e08ab648325a38453f50ca4784b