### PR TITLE
chore: remove unused name event handlers

### DIFF
--- a/src/ui/ui.html
+++ b/src/ui/ui.html
@@ -393,10 +393,6 @@
       // Обработчики для времени
       timeFormat.onchange = updateTimePreview;
 
-      // Стало:
-      namesFormat.onchange = () => {};
-      namesGenderRadios.forEach(radio => radio.addEventListener('change', () => {}));
-      
       // Обработчик для корпоративного домена
       corpDomainMode.addEventListener('change', updateDomainRow);
       


### PR DESCRIPTION
## Summary
- clean up UI name settings by removing leftover empty event handlers

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689e604678f083259e1d653f66b4fbcc