### PR TITLE
build: copy figma ui html and reference dist

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,6 +3,7 @@
   "id": "zalivator",
   "api": "1.0.0",
   "main": "dist/code.js",
+  "ui": "dist/ui.html",
   "editorType": ["figma"],
   "permissions": []
 }

--- a/src/code/index.ts
+++ b/src/code/index.ts
@@ -33,12 +33,9 @@ export function generateRusPlate() {
   const R = pick(RUS_PLATE_REGIONS);
   return `${L1}${D}${L2}${L3}${R}`;
 }
-// Вытаскиваем HTML UI как строку через Vite ?raw и показываем
-// Поддержка старого рантайма Figma: читаем UI как строку без шаблонных строк
-// и без встраивания <script type="module">.
-import uiHtml from "../ui/ui.html?raw";
-const uiString: string = String(uiHtml);
-figma.showUI(uiString, { width: 360, height: 240 });
+// Показываем UI из собранного HTML, встроенного через __html__
+declare const __html__: string;
+figma.showUI(__html__, { width: 360, height: 240 });
 
 type CollectionId =
   | "inn"

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,10 +1,25 @@
 import { defineConfig } from "vite";
 import { resolve } from "path";
+import { copyFileSync } from "fs";
+
+function copyUiHtml() {
+  return {
+    name: "copy-ui-html",
+    writeBundle() {
+      copyFileSync(
+        resolve(__dirname, "src/ui/ui.html"),
+        resolve(__dirname, "dist/ui.html")
+      );
+    }
+  };
+}
+
 export default defineConfig({
   base: "./",
   esbuild: {
     target: "es2016"
   },
+  plugins: [copyUiHtml()],
   build: {
     target: "es2016",
     outDir: "dist",


### PR DESCRIPTION
## Summary
- point Figma manifest to compiled UI html
- load UI from `__html__` and remove raw html import
- copy `src/ui/ui.html` to `dist/ui.html` during build

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689e6acc616c832582add87defb2e336